### PR TITLE
allowing skipping events with a too large nb of MC hits or strips in order to speed up simulation

### DIFF
--- a/src/General/GeneralHitToDigiTool.cxx
+++ b/src/General/GeneralHitToDigiTool.cxx
@@ -57,6 +57,7 @@ AlgTool(type, name, parent) {
     declareProperty("killBadStrips", m_killBadStrips = true );
     declareProperty("killFailed",    m_killFailed    = true );
     declareProperty("totThreshold",  m_totThreshold);
+    declareProperty("maxStrips",  m_maxStrips = 999999999);
 }
 
 
@@ -353,8 +354,21 @@ StatusCode GeneralHitToDigiTool::execute()
 
     SiPlaneMapContainer::SiPlaneMap& siPlaneMap = pObject->getSiPlaneMap();
 
-    // finally make digis from the hits
+    // check number of strips and do nothing if too large.
+    unsigned int nStripsTotal=0;
     SiPlaneMapContainer::SiPlaneMap::iterator itMap=siPlaneMap.begin();
+    for ( ; itMap!=siPlaneMap.end(); ++itMap ) {
+      SiStripList* sList = itMap->second;
+      nStripsTotal+=sList->size();
+    }
+
+    if (nStripsTotal>m_maxStrips) {
+      log<<MSG::INFO<<"Event too big. nStrips="<<nStripsTotal<<" exceeding maximum of "<<m_maxStrips<<". Skipping event."<<endreq;
+      return sc;
+    }
+
+    // finally make digis from the hits
+    itMap=siPlaneMap.begin();
     for ( ; itMap!=siPlaneMap.end(); ++itMap ) {
         SiStripList* sList = itMap->second;
         const TkrVolumeIdentifier volId = itMap->first;  

--- a/src/General/GeneralHitToDigiTool.h
+++ b/src/General/GeneralHitToDigiTool.h
@@ -71,6 +71,8 @@ private:
     /// maximum number of hits per side
     static int    s_maxHits;
 
+    /// max number of strips after which to terminate readout
+    unsigned int m_maxStrips;
 };
 
 #endif

--- a/src/Simple/SimpleMcToHitTool.cxx
+++ b/src/Simple/SimpleMcToHitTool.cxx
@@ -41,6 +41,7 @@ SimpleMcToHitTool::SimpleMcToHitTool(const std::string& type,
     declareProperty("test", m_test = false);
     declareProperty("fluctuate", m_fluctuate = false);
     declareProperty("alignmentMode", m_alignmentMode=0);
+    declareProperty("maxMCHits",m_maxMCHits=999999999);
 }
 
 StatusCode SimpleMcToHitTool::initialize() {
@@ -187,6 +188,11 @@ SiPlaneMapContainer::SiPlaneMap SimpleMcToHitTool::createSiHits(
     log << endreq;
 
     if (nHits==0) return siPlaneMap;
+
+    if (nHits> m_maxMCHits) {
+      log << MSG::INFO<<"Number of MC hits nhits="<<nHits<<" exceeds maximum of "<<m_maxMCHits<<". Skipping event."<<endreq;
+      return siPlaneMap;
+    }
 
     // This assumes that the number of ladders equals the number of
     // wafers/ladder.  Not true for the BFEM/BTEM!

--- a/src/Simple/SimpleMcToHitTool.h
+++ b/src/Simple/SimpleMcToHitTool.h
@@ -61,6 +61,8 @@ class SimpleMcToHitTool : public AlgTool, virtual public IMcToHitTool {
     int  m_alignmentMode;
     /// do strip-wise "landau" fluctuations
     bool m_fluctuate;
+    /// limit number of MC hits to eliminate ultra-large events.
+    unsigned int m_maxMCHits;
 };
 
 #endif


### PR DESCRIPTION
This is an original idea of Markus in order to speed up the simulation of proton for IGRB analysis.
My preliminary tests show that for gamma up to E=3TeV, it is safe to use the following job options \:
ToolSvc.SimpleMcToHitTool.maxMCHits=32000
ToolSvc.GeneralHitToDigiTool.maxStrips = 100000;
